### PR TITLE
[PAY-037] 퀴즈 페이지 margin, constraint 수정

### DIFF
--- a/PayKids/presentation/src/main/res/layout/fragment_quiz_image.xml
+++ b/PayKids/presentation/src/main/res/layout/fragment_quiz_image.xml
@@ -46,7 +46,7 @@
         android:id="@+id/tv_question"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
+        android:layout_marginHorizontal="20dp"
         android:layout_marginTop="102dp"
         android:fontFamily="@font/nanumsquare_extra_bold"
         android:gravity="center_horizontal"

--- a/PayKids/presentation/src/main/res/layout/fragment_quiz_multiple_choice.xml
+++ b/PayKids/presentation/src/main/res/layout/fragment_quiz_multiple_choice.xml
@@ -46,7 +46,7 @@
         android:id="@+id/tv_question"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
+        android:layout_marginHorizontal="20.5dp"
         android:layout_marginTop="118dp"
         android:fontFamily="@font/nanumsquare_extra_bold"
         android:gravity="center_horizontal"

--- a/PayKids/presentation/src/main/res/layout/fragment_quiz_multiple_choice_img.xml
+++ b/PayKids/presentation/src/main/res/layout/fragment_quiz_multiple_choice_img.xml
@@ -49,7 +49,7 @@
         android:id="@+id/tv_question"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="16dp"
+        android:layout_marginHorizontal="20.5dp"
         android:layout_marginBottom="40dp"
         android:fontFamily="@font/nanumsquare_extra_bold"
         android:gravity="center_horizontal"

--- a/PayKids/presentation/src/main/res/layout/fragment_quiz_short_answer.xml
+++ b/PayKids/presentation/src/main/res/layout/fragment_quiz_short_answer.xml
@@ -45,116 +45,113 @@
             android:src="@drawable/ic_left_black" />
     </Toolbar>
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/nsv_content"
+    <TextView
+        android:id="@+id/tv_question"
         android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:layout_marginTop="8dp"
-
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/nanumsquare_extra_bold"
+        android:gravity="center_horizontal"
+        android:textColor="@color/black"
+        android:textSize="24sp"
+        tools:text="10,000원 권 지폐에는\n어떤 인물이 그려져 있을까요?"
+        android:layout_marginTop="159dp"
+        android:layout_marginHorizontal="4.5dp"
+        app:layout_constraintStart_toStartOf="@id/et_answer"
+        app:layout_constraintEnd_toEndOf="@id/et_answer"
         app:layout_constraintTop_toBottomOf="@id/tb_quiz"
-        app:layout_constraintBottom_toTopOf="@id/tv_decision"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent">
+        />
 
-        <LinearLayout
-            android:layout_width="match_parent"
+    <LinearLayout
+        android:id="@+id/ll_correct_answer"
+        android:layout_width="0dp"
+        android:layout_height="44dp"
+        android:layout_marginTop="18dp"
+        android:layout_marginHorizontal="4.5dp"
+        android:background="@drawable/shape_quiz_correct_answer_box"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:visibility="invisible"
+        app:layout_constraintStart_toStartOf="@id/et_answer"
+        app:layout_constraintEnd_toEndOf="@id/et_answer"
+        app:layout_constraintTop_toBottomOf="@id/tv_question" >
+
+        <ImageView
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:orientation="vertical"
-            android:paddingHorizontal="16dp">
+            android:contentDescription="@null"
+            android:paddingStart="15dp"
+            android:src="@drawable/ic_check_white" />
 
-            <TextView
-                android:id="@+id/tv_question"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/nanumsquare_extra_bold"
-                android:gravity="center_horizontal"
-                android:textColor="@color/black"
-                android:textSize="24sp"
-                tools:text="10,000원 권 지폐에는\n어떤 인물이 그려져 있을까요?" />
+        <TextView
+            android:id="@+id/tv_correct_answer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="@font/nanumsquare_extra_bold"
+            android:gravity="center"
+            android:text="@string/text_correct_answer"
+            android:textColor="@android:color/white"
+            android:textSize="18sp" />
+    </LinearLayout>
 
-            <LinearLayout
-                android:id="@+id/ll_correct_answer"
-                android:layout_width="match_parent"
-                android:layout_height="44dp"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/shape_quiz_correct_answer_box"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:visibility="invisible">
+    <LinearLayout
+        android:id="@+id/ll_wrong_answer"
+        android:layout_width="0dp"
+        android:layout_height="44dp"
+        android:layout_marginTop="18dp"
+        android:layout_marginHorizontal="4.5dp"
+        android:background="@drawable/shape_quiz_wrong_answer_box"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:visibility="invisible"
+        app:layout_constraintStart_toStartOf="@id/et_answer"
+        app:layout_constraintEnd_toEndOf="@id/et_answer"
+        app:layout_constraintTop_toBottomOf="@id/tv_question">
 
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:contentDescription="@null"
-                    android:paddingStart="15dp"
-                    android:src="@drawable/ic_check_white" />
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@null"
+            android:paddingStart="15dp"
+            android:src="@drawable/ic_cancel_white" />
 
-                <TextView
-                    android:id="@+id/tv_correct_answer"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:fontFamily="@font/nanumsquare_extra_bold"
-                    android:gravity="center"
-                    android:text="@string/text_correct_answer"
-                    android:textColor="@android:color/white"
-                    android:textSize="18sp" />
-            </LinearLayout>
+        <TextView
+            android:id="@+id/tv_wrong_answer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:fontFamily="@font/nanumsquare_extra_bold"
+            android:gravity="center"
+            android:text="@string/text_wrong_answer"
+            android:textColor="@android:color/white"
+            android:textSize="18sp" />
+    </LinearLayout>
 
-            <LinearLayout
-                android:id="@+id/ll_wrong_answer"
-                android:layout_width="match_parent"
-                android:layout_height="44dp"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/shape_quiz_wrong_answer_box"
-                android:gravity="center_vertical"
-                android:orientation="horizontal"
-                android:visibility="invisible">
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:contentDescription="@null"
-                    android:paddingStart="15dp"
-                    android:src="@drawable/ic_cancel_white" />
-
-                <TextView
-                    android:id="@+id/tv_wrong_answer"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:fontFamily="@font/nanumsquare_extra_bold"
-                    android:gravity="center"
-                    android:text="@string/text_wrong_answer"
-                    android:textColor="@android:color/white"
-                    android:textSize="18sp" />
-            </LinearLayout>
-
-            <EditText
-                android:id="@+id/et_answer"
-                android:layout_width="match_parent"
-                android:layout_height="95dp"
-                android:layout_marginTop="16dp"
-                android:background="@drawable/shape_quiz_answer_input_box"
-                android:fontFamily="@font/nanumsquare_extra_bold"
-                android:gravity="center"
-                android:hint="@string/hint_input_answer"
-                android:importantForAutofill="no"
-                android:inputType="text"
-                android:paddingHorizontal="22.5dp"
-                android:textColor="@color/black"
-                android:textColorHint="@color/gray2"
-                android:textSize="22sp" />
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+    <EditText
+        android:id="@+id/et_answer"
+        android:layout_width="match_parent"
+        android:layout_height="95dp"
+        android:layout_marginTop="75.5dp"
+        android:layout_marginHorizontal="15.5dp"
+        android:background="@drawable/shape_quiz_answer_input_box"
+        android:fontFamily="@font/nanumsquare_extra_bold"
+        android:gravity="center"
+        android:hint="@string/hint_input_answer"
+        android:importantForAutofill="no"
+        android:inputType="text"
+        android:textColor="@color/black"
+        android:textColorHint="@color/gray2"
+        android:textSize="22sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tv_question" />
 
     <TextView
         android:id="@+id/tv_decision"
         android:layout_width="0dp"
-        android:layout_height="56dp"
-        android:layout_marginHorizontal="12dp"
-        android:layout_marginBottom="12dp"
+        android:layout_height="50dp"
+        android:layout_marginHorizontal="4.5dp"
+        android:layout_marginBottom="61.5dp"
         android:background="@drawable/shape_quiz_decision_box"
         android:fontFamily="@font/nanumsquare_extra_bold"
         android:gravity="center"
@@ -162,7 +159,7 @@
         android:textColor="@android:color/white"
         android:textSize="18sp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="@id/et_answer"
+        app:layout_constraintEnd_toEndOf="@id/et_answer" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/PayKids/presentation/src/main/res/layout/fragment_quiz_short_answer_img.xml
+++ b/PayKids/presentation/src/main/res/layout/fragment_quiz_short_answer_img.xml
@@ -47,17 +47,18 @@
 
     <TextView
         android:id="@+id/tv_question"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="26dp"
+        android:layout_marginHorizontal="4.5dp"
         tools:text="10,000원 권 지폐에는\n어떤 인물이 그려져 있을까요?"
         android:gravity="center_horizontal"
         android:textSize="22sp"
         android:textColor="@color/black"
         android:fontFamily="@font/nanumsquare_extra_bold"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/fl_image"
-        android:layout_marginBottom="26dp"/>
+        app:layout_constraintStart_toStartOf="@id/et_answer"
+        app:layout_constraintEnd_toEndOf="@id/et_answer"
+        app:layout_constraintBottom_toTopOf="@id/fl_image" />
 
     <FrameLayout
         android:id="@+id/fl_image"
@@ -152,7 +153,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/tv_decision"
-        android:layout_marginBottom="115.5dp"
+        android:layout_marginBottom="117dp"
         android:layout_marginHorizontal="15.5dp"
         android:textColor="@color/black"
         android:textSize="22sp"
@@ -161,8 +162,7 @@
         android:hint="정답 입력하기..."
         android:textColorHint="@color/gray2"
         android:gravity="center"
-        android:background="@drawable/shape_quiz_answer_input_box"
-        android:paddingHorizontal="22.5dp" />
+        android:background="@drawable/shape_quiz_answer_input_box" />
 
     <TextView
         android:id="@+id/tv_decision"


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI/UX 개선**
	- 퀴즈 화면의 여러 레이아웃에서 질문 텍스트뷰의 수평 여백을 조정했습니다.
	- 단답형 퀴즈 화면의 레이아웃을 개선하여 질문, 정답, 오답 표시 영역을 재구성했습니다.
	- 레이아웃 컴포넌트의 제약 조건과 마진을 최적화하여 화면 구성을 더욱 정교하게 만들었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->